### PR TITLE
fix(search): if substitutions are defined, we should tokenize input based on those as well

### DIFF
--- a/packages/search/src/lib/factories.spec.ts
+++ b/packages/search/src/lib/factories.spec.ts
@@ -1,53 +1,122 @@
-import { constructTransducer } from './factories';
-
+import { constructSearchers, constructTransducer } from './factories';
+import {
+  MTDExportFormat,
+  L1Index,
+  L2Index,
+  LanguageConfigurationExportFormat,
+} from './mtd';
+import index1 from '../../testdata/search_L1EngIndex_numbers.json';
+import index2 from '../../testdata/search_L1EngIndex_numbers.json';
 describe('transducer', () => {
-    it('should be able to search', () => {
-      const dummyTerms = ['dog', 'cat', 'frog', 'kart'];
+  it('should be able to search', () => {
+    const dummyTerms = ['dog', 'cat', 'frog', 'kart'];
 
-      expect(
-        constructTransducer({
-          terms: dummyTerms,
-          include_distance: false,
-        }).transduce('kat', 1)
-      ).toEqual(['cat', 'kart']);
-    });
-
-    it('should return only maximum number of candidates in alphabetical order', () => {
-      const dummyTerms = ['rat', 'cat', 'bat', 'mat', 'hat', 'pat'];
-
-      const transducer = constructTransducer({
+    expect(
+      constructTransducer({
         terms: dummyTerms,
         include_distance: false,
-        maximum_candidates: 3
-      });
-
-      const result = transducer.transduce('kat', 1);
-
-      expect(result.length).toEqual(3);
-      expect(result[0]).toEqual('bat');
-      expect(result[1]).toEqual('cat');
-      expect(result[2]).toEqual('hat');
-    });
-
-    it('should return only maximum number of candidates sorted by distance THEN alphabetized', () => {
-      const dummyTerms = ['rat', 'cat', 'kit', 'Cat', 'Kart', 'kart'];
-
-      const transducer = constructTransducer({
-        terms: dummyTerms,
-        include_distance: true,
-        maximum_candidates: 10,
-        case_insensitive_sort: false,
-        sort_candidates: true
-      });
-
-      const result = transducer.transduce('kat', 2);
-
-      expect(result.length).toEqual(dummyTerms.length);
-      expect(result[0]).toEqual(['cat',1])
-      expect(result[1]).toEqual(['Cat',1])
-      expect(result[2]).toEqual(['kart', 1])
-      expect(result[3]).toEqual(['kit', 1])
-      expect(result[5]).toEqual(['Kart', 2])
-    });
+      }).transduce('kat', 1)
+    ).toEqual(['cat', 'kart']);
   });
-  
+
+  it('should be able to search with edit distance based on tokens from substitution costs', () => {
+    // @ts-ignore
+    const l1_index_english_numbers: L1Index = index1;
+    // @ts-ignore
+    const l2_index_english_numbers: L2Index = index2;
+    const exportedData: MTDExportFormat = {
+      config: {
+        L1: 'Test',
+        L2: 'test',
+        l1_search_config: {
+          substitutionCosts: { foo: { one: 0.0 }, one: { foo: 0.0 } },
+        },
+        l1_search_strategy: 'weighted_levenstein',
+        l2_search_strategy: 'weighted_levenstein',
+        l1_stemmer: 'none',
+        l2_stemmer: 'none',
+        l1_normalization_transducer: {},
+        l2_normalization_transducer: {},
+        build: 'test',
+        optional_field_name: 'optional',
+        alphabet: [
+          'a',
+          'b',
+          'c',
+          'd',
+          'e',
+          'f',
+          'g',
+          'h',
+          'i',
+          'j',
+          'k',
+          'l',
+          'm',
+          'n',
+          'o',
+          'p',
+          'q',
+          'r',
+          's',
+          't',
+          'u',
+          'v',
+          'w',
+          'x',
+          'y',
+          'z',
+        ],
+      },
+      data: [
+        { word: 'test', definition: 'test', entryID: '0', sorting_form: [0] },
+      ],
+      l1_index: l1_index_english_numbers,
+      l2_index: l2_index_english_numbers,
+    };
+    const [l1_searcher, l2_searcher] = constructSearchers(exportedData);
+    expect(l1_searcher.search('one', 1, true).length).toEqual(4);
+    expect(l1_searcher.search('foo', 1, true).length).toEqual(4); // If foo and one are both equivalent according to the substitution costs, then the edit distance should be calculated on that and 'foo' becomes essentially an alias for 'one'
+    expect(l1_searcher.search('foo', 1, true)).toEqual(
+      l1_searcher.search('one', 1, true)
+    );
+  });
+
+  it('should return only maximum number of candidates in alphabetical order', () => {
+    const dummyTerms = ['rat', 'cat', 'bat', 'mat', 'hat', 'pat'];
+
+    const transducer = constructTransducer({
+      terms: dummyTerms,
+      include_distance: false,
+      maximum_candidates: 3,
+    });
+
+    const result = transducer.transduce('kat', 1);
+
+    expect(result.length).toEqual(3);
+    expect(result[0]).toEqual('bat');
+    expect(result[1]).toEqual('cat');
+    expect(result[2]).toEqual('hat');
+  });
+
+  it('should return only maximum number of candidates sorted by distance THEN alphabetized', () => {
+    const dummyTerms = ['rat', 'cat', 'kit', 'Cat', 'Kart', 'kart'];
+
+    const transducer = constructTransducer({
+      terms: dummyTerms,
+      include_distance: true,
+      maximum_candidates: 10,
+      case_insensitive_sort: false,
+      sort_candidates: true,
+    });
+
+    const result = transducer.transduce('kat', 2);
+
+    expect(result.length).toEqual(dummyTerms.length);
+    expect(result[0]).toEqual(['cat', 1]);
+    expect(result[1]).toEqual(['Cat', 1]);
+    expect(result[2]).toEqual(['kart', 1]);
+    expect(result[3]).toEqual(['kit', 1]);
+    expect(result[5]).toEqual(['Kart', 2]);
+  });
+});

--- a/packages/search/src/lib/factories.ts
+++ b/packages/search/src/lib/factories.ts
@@ -78,13 +78,25 @@ export function constructSearchers(
     l1_index,
     mtdExportFormat.config.l1_search_config ?? undefined
   );
+  const l1SubstitutionCosts =
+    mtdExportFormat.config.l1_search_config?.substitutionCosts;
+  const l2SubstitutionCosts =
+    mtdExportFormat.config.l2_search_config?.substitutionCosts;
+  let l1_tokens = mtdExportFormat.config.alphabet;
+  if (l1SubstitutionCosts) {
+    l1_tokens = [...l1_tokens, ...Object.keys(l1SubstitutionCosts)];
+  }
+  let l2_tokens = mtdExportFormat.config.alphabet; // TODO: This isn't really right, not sure how we should tokenize though
+  if (l2SubstitutionCosts) {
+    l2_tokens = [...l2_tokens, ...Object.keys(l2SubstitutionCosts)];
+  }
   // Create L1 Search Object
   const l1_search = new MTDSearch({
     transducer: l1_transducer,
     index: l1_index,
     searchType:
       mtdExportFormat.config.l1_search_strategy ?? 'liblevenstein_automata',
-    tokens: mtdExportFormat.config.alphabet,
+    tokens: l1_tokens,
   });
   // Load L2 Index
   const l2_index = new Index({
@@ -104,7 +116,7 @@ export function constructSearchers(
     index: l2_index,
     searchType:
       mtdExportFormat.config.l2_search_strategy ?? 'liblevenstein_automata',
-    tokens: mtdExportFormat.config.alphabet, // TODO: This isn't really right, not sure how we should tokenize though
+    tokens: l2_tokens,
   });
   return [l1_search, l2_search];
 }

--- a/packages/search/src/lib/search.spec.ts
+++ b/packages/search/src/lib/search.spec.ts
@@ -1,4 +1,12 @@
-import { create_normalization_function, englishStemmer, sortResults, Result, MTDSearch, Index, MTDParams } from './search';
+import {
+  create_normalization_function,
+  englishStemmer,
+  sortResults,
+  Result,
+  MTDSearch,
+  Index,
+  MTDParams,
+} from './search';
 import { DistanceCalculator } from './weighted.levenstein';
 import index1 from '../../testdata/search_L1EngIndex_numbers.json';
 import { L1Index } from './mtd';
@@ -22,7 +30,7 @@ describe('normalize', () => {
 
   it('should NOT lowercase', () => {
     const defaultNormalization = create_normalization_function({
-      lower: false
+      lower: false,
     });
     expect(defaultNormalization('rElAtE')).toEqual('rElAtE');
   });
@@ -31,7 +39,7 @@ describe('normalize', () => {
     const defaultConfig = create_normalization_function({
       lower: false,
       remove_combining_characters: true,
-    })
+    });
     expect(defaultConfig('ÁÉÍÓÚäëïöüÇÅ')).toEqual('AEIOUaeiouCA');
   });
 
@@ -39,10 +47,9 @@ describe('normalize', () => {
     const defaultConfig = create_normalization_function({
       lower: true,
       remove_combining_characters: true,
-    })
+    });
     expect(defaultConfig('ÁÉÍÓÚäëïöü')).toEqual('aeiouaeiou');
   });
-
 
   it('should remove punctuation listed by remove_punctionation', () => {
     const defaultNormalization = create_normalization_function({
@@ -59,7 +66,7 @@ describe('normalize', () => {
       lower: true,
       unicode_normalization: 'NFC',
       replace_rules: {},
-      remove_punctuation: "[.,]",
+      remove_punctuation: '[.,]',
     });
     expect(defaultNormalization('a,a;a.:')).toEqual('aa;a:');
   });
@@ -67,10 +74,10 @@ describe('normalize', () => {
   it('should replace according to rules', () => {
     const defaultNormalization = create_normalization_function({
       replace_rules: {
-        'k':'c',
-        'i':'a',
-        's':'t'
-      }
+        k: 'c',
+        i: 'a',
+        s: 't',
+      },
     });
     expect(defaultNormalization('kat')).toEqual('cat');
     expect(defaultNormalization('cat')).not.toEqual('kat');
@@ -81,8 +88,8 @@ describe('normalize', () => {
   it('should not choke if asked to replace same letter', () => {
     const defaultNormalization = create_normalization_function({
       replace_rules: {
-        'r':'r'
-      }
+        r: 'r',
+      },
     });
     expect(defaultNormalization('hammer')).toEqual('hammer');
   });
@@ -90,9 +97,10 @@ describe('normalize', () => {
   it('should replace with last rule listed', () => {
     const defaultNormalization = create_normalization_function({
       replace_rules: {
-        'r':'z',
-        'r':'l'
-      }
+        r: 'z',
+        // @ts-ignore: deliberately testing a duplicate key.
+        r: 'l',
+      },
     });
     expect(defaultNormalization('hammerer')).toEqual('hammelel');
   });
@@ -100,9 +108,9 @@ describe('normalize', () => {
   it('should replace mulitple letters', () => {
     const defaultNormalization = create_normalization_function({
       replace_rules: {
-        'ch':'k',
-        'r':'rr'
-      }
+        ch: 'k',
+        r: 'rr',
+      },
     });
     expect(defaultNormalization('chip')).toEqual('kip');
     expect(defaultNormalization('hammerer')).toEqual('hammerrerr');
@@ -113,22 +121,21 @@ describe('normalize', () => {
       lower: true,
       unicode_normalization: 'NFC',
       replace_rules: {
-        'a':'e'
+        a: 'e',
       },
       remove_punctuation: "[-']",
     });
     expect(defaultNormalization("A,j'a--")).toEqual('e,je');
   });
-
 });
 
 describe('sortResults', () => {
   it('should sort by Levenstein distance (first value)', () => {
-    const result1: Result = [1, 'result1', [[ 'entryIndex', 2]], 1];
-    const result2: Result = [0, 'result2', [[ 'entryIndex', 2]], 1];
+    const result1: Result = [1, 'result1', [['entryIndex', 2]], 1];
+    const result2: Result = [0, 'result2', [['entryIndex', 2]], 1];
     const result3: Result = [0.5, 'result3', [['entryIndex', 2]], 1];
-      
-    const givenArray = [result1, result2, result3]
+
+    const givenArray = [result1, result2, result3];
 
     const sortResultsOutput = sortResults(givenArray);
 
@@ -138,11 +145,11 @@ describe('sortResults', () => {
   });
 
   it('should sort by BM25 score (last value) when Levenstein distance is equal', () => {
-    const result1: Result = [0, 'result1', [[ 'entryIndex', 2]], 1];
-    const result2: Result = [0, 'result2', [[ 'entryIndex', 2]], 0];
-    const result3: Result = [0, 'result3', [['entryIndex', 2]], .5];
-      
-    const givenArray = [result1, result2, result3]
+    const result1: Result = [0, 'result1', [['entryIndex', 2]], 1];
+    const result2: Result = [0, 'result2', [['entryIndex', 2]], 0];
+    const result3: Result = [0, 'result3', [['entryIndex', 2]], 0.5];
+
+    const givenArray = [result1, result2, result3];
 
     const sortResultsOutput = sortResults(givenArray);
 
@@ -152,12 +159,12 @@ describe('sortResults', () => {
   });
 
   it('should sort by Lev score first, BM25 score second', () => {
-    const result1: Result = [0, 'result1', [[ 'entryIndex', 2]], 1];
-    const result2: Result = [0, 'result2', [[ 'entryIndex', 2]], 0];
-    const result3: Result = [.5, 'result3', [['entryIndex', 2]], .5];
-    const result4: Result = [.5, 'result4', [['entryIndex', 2]], 1];
-      
-    const givenArray = [result1, result2, result3, result4]
+    const result1: Result = [0, 'result1', [['entryIndex', 2]], 1];
+    const result2: Result = [0, 'result2', [['entryIndex', 2]], 0];
+    const result3: Result = [0.5, 'result3', [['entryIndex', 2]], 0.5];
+    const result4: Result = [0.5, 'result4', [['entryIndex', 2]], 1];
+
+    const givenArray = [result1, result2, result3, result4];
 
     const sortResultsOutput = sortResults(givenArray);
 
@@ -167,19 +174,18 @@ describe('sortResults', () => {
     expect(sortResultsOutput[3]).toEqual(result3);
   });
 
-  it('should not blow up if given an empty Result set', () => {      
-    const givenArray: Result[] = []
+  it('should not blow up if given an empty Result set', () => {
+    const givenArray: Result[] = [];
 
     expect(sortResults(givenArray)).toEqual([]);
   });
-
 });
 
 describe('Index', () => {
   it('should work with empty data', () => {
     const basicIndexParams = {
-      data: {}
-    }
+      data: {},
+    };
     const index = new Index(basicIndexParams);
 
     expect(index.data).toEqual({});
@@ -187,49 +193,48 @@ describe('Index', () => {
 
   it('should construct w given data', () => {
     const basicIndexParams = {
-      data: {'one': {}}
-    }
+      data: { one: {} },
+    };
     const index = new Index(basicIndexParams);
 
-    expect(index.data).toEqual({'one': {}});
+    expect(index.data).toEqual({ one: {} });
   });
 });
 
 describe('MTDSearch class', () => {
-
   let mtdSearch: MTDSearch;
 
   const basicIndexParams = {
-    data: {'one': {}, 'two': {}}
-  }
+    data: { one: {}, two: {} },
+  };
 
   const mtdParams: MTDParams = {
     transducer: {},
     index: new Index(basicIndexParams),
     searchType: 'weighted_levenstein',
-    tokens: undefined
-  }
+    tokens: undefined,
+  };
 
   beforeEach(() => {
     mtdSearch = new MTDSearch(mtdParams);
-  })
+  });
 
   it('should construct with undefined tokens', () => {
     // arrange
-    mtdSearch = new MTDSearch(mtdParams)
+    mtdSearch = new MTDSearch(mtdParams);
 
     // act + assert
-    expect(mtdSearch.indexTerms).toEqual(['one','two']);
+    expect(mtdSearch.indexTerms).toEqual(['one', 'two']);
     expect(mtdSearch.tokenizer).toEqual(undefined);
   });
 
   it('should construct with defined tokens', () => {
     // arrange
-    mtdParams.tokens = ['a','b','c']
-    mtdSearch = new MTDSearch(mtdParams)
-  
+    mtdParams.tokens = ['a', 'b', 'c'];
+    mtdSearch = new MTDSearch(mtdParams);
+
     // act + assert
-    expect(mtdSearch.indexTerms).toEqual(['one','two']);
+    expect(mtdSearch.indexTerms).toEqual(['one', 'two']);
     expect(mtdSearch.tokenizer).not.toEqual(undefined);
   });
 
@@ -243,28 +248,63 @@ describe('MTDSearch class', () => {
   // });
 
   describe('search method', () => {
-
+    // @ts-ignore: I don't understand why this doesn't work
     const l1_index_english_numbers: L1Index = index1;
 
     it('should return correct search results for single word query', () => {
-      const query = 'one'; 
+      const query = 'one';
       const maximum_edit_distance = 2;
       const sort = false;
-  
+
       mtdParams.transducer = new DistanceCalculator({});
-      mtdParams.tokens = ['a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z'];
+      mtdParams.tokens = [
+        'a',
+        'b',
+        'c',
+        'd',
+        'e',
+        'f',
+        'g',
+        'h',
+        'i',
+        'j',
+        'k',
+        'l',
+        'm',
+        'n',
+        'o',
+        'p',
+        'q',
+        'r',
+        's',
+        't',
+        'u',
+        'v',
+        'w',
+        'x',
+        'y',
+        'z',
+      ];
 
       mtdParams.index.data = l1_index_english_numbers;
       mtdSearch = new MTDSearch(mtdParams);
 
       const result = mtdSearch.search(query, maximum_edit_distance, sort);
       const expectedResult = [
-        [0,"DataNamedThis00",[["word",0,],],0.4423756753387274,],
-        [0,"DataNamedThis05",[["word",1,],],0.3305391282025323,],
-        [0,"DataNamedThis08",[["word",0,],],0.3305391282025323,],
-        [0,"DataNamedThis09",[["word",0,],["word",2,],],0.4100067234846742,]
+        [0, 'DataNamedThis00', [['word', 0]], 0.4423756753387274],
+        [0, 'DataNamedThis05', [['word', 1]], 0.3305391282025323],
+        [0, 'DataNamedThis08', [['word', 0]], 0.3305391282025323],
+        [
+          0,
+          'DataNamedThis09',
+          [
+            ['word', 0],
+            ['word', 2],
+          ],
+          0.4100067234846742,
+        ],
       ];
-  
+
       // of the 10 given terms, only 4 should be returned
       expect(result.length).toEqual(4);
       expect(result).toEqual(expectedResult);
@@ -275,26 +315,26 @@ describe('MTDSearch class', () => {
     const query = 'two hundred';
     const maximum_edit_distance = 2;
     const sort = false;
-  
+
     const result = mtdSearch.search(query, maximum_edit_distance, sort);
     const expectedResult = [
-      [1.5,"DataNamedThis01",[["word",0,],],2.220543387065661,],
-      [1.5,"DataNamedThis08",[["word",1,],],1.1000228598850477,],
-      [1.5,"DataNamedThis09",[["word",1,],],0.8780451527333565,]
+      [1.5, 'DataNamedThis01', [['word', 0]], 2.220543387065661],
+      [1.5, 'DataNamedThis08', [['word', 1]], 1.1000228598850477],
+      [1.5, 'DataNamedThis09', [['word', 1]], 0.8780451527333565],
     ];
-  
+
     // of the 10 given terms, only 3 should be returned
     expect(result.length).toEqual(3);
     expect(result).toEqual(expectedResult);
   });
-  
+
   it('should return correct results for single non-existent word query', () => {
     const query = 'nonExistentWord';
     const maximum_edit_distance = 2;
     const sort = false;
-  
+
     const result = mtdSearch.search(query, maximum_edit_distance, sort);
-  
+
     expect(result.length).toEqual(0);
   });
 
@@ -302,18 +342,24 @@ describe('MTDSearch class', () => {
     const query = 'one nonExistentWord';
     const maximum_edit_distance = 2;
     const sort = false;
-  
+
     const result = mtdSearch.search(query, maximum_edit_distance, sort);
     const expectedResult = [
-      [1.5,"DataNamedThis00",[["word",0,],],0.4423756753387274,],
-      [1.5,"DataNamedThis05",[["word",1,],],0.3305391282025323,],
-      [1.5,"DataNamedThis08",[["word",0,],],0.3305391282025323,],
-      [1.5,"DataNamedThis09",[["word",0,],["word",2,],],0.4100067234846742,]
+      [1.5, 'DataNamedThis00', [['word', 0]], 0.4423756753387274],
+      [1.5, 'DataNamedThis05', [['word', 1]], 0.3305391282025323],
+      [1.5, 'DataNamedThis08', [['word', 0]], 0.3305391282025323],
+      [
+        1.5,
+        'DataNamedThis09',
+        [
+          ['word', 0],
+          ['word', 2],
+        ],
+        0.4100067234846742,
+      ],
     ];
 
     expect(result.length).toEqual(4);
     expect(result).toEqual(expectedResult);
   });
-  
 });
-

--- a/packages/search/src/lib/utils.spec.ts
+++ b/packages/search/src/lib/utils.spec.ts
@@ -1,34 +1,34 @@
-import { Counter } from "./utils";
+import { Counter } from './utils';
 
 describe('Counter', () => {
-    it('should correctly update the counter', () => {
-      const array = ['apple', 'banana', 'apple', 'cherry'];
-      const counter = new Counter(array);
-  
-      expect(counter.counter).toEqual({
-        apple: 2,
-        banana: 1,
-        cherry: 1,
-      });
-    });
-  
-    it('should increment the count when adding repeat value', () => {
-      const counter = new Counter([]);
-      counter.add('apple');
-      counter.add('apple');
-  
-      expect(counter.counter.apple).toBe(2);
-    });
+  it('should correctly update the counter', () => {
+    const array = ['apple', 'banana', 'apple', 'cherry'];
+    const counter = new Counter(array);
 
-    it('should increment the count when adding already existing value', () => {
-        const counter = new Counter(['apple']);
-        counter.add('apple');
-    
-        expect(counter.counter.apple).toBe(2);
-      });
-  
-    it('should handle an empty array', () => {
-      const counter = new Counter([]);
-      expect(counter.counter).toEqual({});
+    expect(counter.counter).toEqual({
+      apple: 2,
+      banana: 1,
+      cherry: 1,
     });
   });
+
+  it('should increment the count when adding repeat value', () => {
+    const counter = new Counter([]);
+    counter.add('apple');
+    counter.add('apple');
+
+    expect(counter.counter['apple']).toBe(2);
+  });
+
+  it('should increment the count when adding already existing value', () => {
+    const counter = new Counter(['apple']);
+    counter.add('apple');
+
+    expect(counter.counter['apple']).toBe(2);
+  });
+
+  it('should handle an empty array', () => {
+    const counter = new Counter([]);
+    expect(counter.counter).toEqual({});
+  });
+});


### PR DESCRIPTION
Previously, we tokenized input based on the alphabet, to allow weighted multigraph substitutions, but if there are substitutions defined that are not in the alphabet, they would be missed. So, we should tokenize on the union of the alphabet and the substitution targets.